### PR TITLE
Update unit description in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ All responses are JSON-encoded. The returned objects are currently bare-bones, b
 | name | Gygja | |
 | hp | 38 | |
 | size | 4 |  |
-| randompaths | paths: 'SDNB', levels: '1', chance: '100', paths: 'SDNB', levels: '1', chance: '100', paths: 'SDNB', levels: '1', chance: '10' | Appears only for units with random paths, returned as an array of objects |
+| randompaths | {paths: 'SDNB', levels: '1', chance: '100'}, 
+{paths: 'SDNB', levels: '1', chance: '100'}, 
+{paths: 'SDNB', levels: '1', chance: '10'} | Appears only for units with random paths, returned as an array of objects |
 | screenshot | /units/785/screenshot | Link to dom5inspector screenshot |
 
 

--- a/README.md
+++ b/README.md
@@ -114,9 +114,7 @@ All responses are JSON-encoded. The returned objects are currently bare-bones, b
 | name | Gygja | |
 | hp | 38 | |
 | size | 4 |  |
-| randompaths | {paths: 'SDNB', levels: '1', chance: '100'}, 
-{paths: 'SDNB', levels: '1', chance: '100'}, 
-{paths: 'SDNB', levels: '1', chance: '10'} | Appears only for units with random paths, returned as an array of objects |
+| randompaths | {paths: 'SDNB', levels: '1', chance: '100'}, {paths: 'SDNB', levels: '1', chance: '100'}, {paths: 'SDNB', levels: '1', chance: '10'} | Appears only for units with random paths, returned as an array of objects |
 | screenshot | /units/785/screenshot | Link to dom5inspector screenshot |
 
 

--- a/README.md
+++ b/README.md
@@ -110,11 +110,12 @@ All responses are JSON-encoded. The returned objects are currently bare-bones, b
 
 | Property | Example value | Notes | 
 | -------- | ------------- | ----------- |
-| id | 538 |  |
-| name | Theurg Communicant | |
-| size | 2 |  |
-| hp | 10 | |
-| screenshot | /units/538/screenshot | Link to dom5inspector screenshot |
+| id | 785 |  |
+| name | Gygja | |
+| hp | 38 | |
+| size | 4 |  |
+| randompaths | paths: 'SDNB', levels: '1', chance: '100', paths: 'SDNB', levels: '1', chance: '100', paths: 'SDNB', levels: '1', chance: '10' | Appears only for units with random paths, returned as an array of objects |
+| screenshot | /units/785/screenshot | Link to dom5inspector screenshot |
 
 
 ### Site


### PR DESCRIPTION
Updated unit description in README.md to include a reference to 'randompaths' that is returned if a unit has randompaths. Provided example of how randompaths would be returned. And changed the order of hp and size to fall in line with what the API returns when you make the call.